### PR TITLE
sets the correct env for graphql sub

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,7 +9,7 @@ import "./global-styles/reset.scss";
 import "./global-styles/index.scss";
 
 const subscriptionClient = new Transport.SubscriptionClient(
-  `ws://${import.meta.env.VITE_DESKTOP_BRIDGE_URI}`,
+  `ws://${import.meta.env.VITE_API_GATEWAY_URI}`,
   { reconnect: true }
 );
 


### PR DESCRIPTION
Wrong env variable is being used for graphql, currently using desktop-bridge env. The change switches the env to the api gateway
