### PR TITLE
ignore config-env_copy.js

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ node_modules
 build
 .dockerignore
 Dockerfile
+public/config-env_copy.js


### PR DESCRIPTION
Ignore config-env_copy.js to avoid build issues on circleci
