### PR TITLE
moves keycloak host to config

### DIFF
--- a/public/config-env_copy.js
+++ b/public/config-env_copy.js
@@ -2,3 +2,4 @@ window.config_MAPBOX_API_KEY = "";
 window.config_MAPBOX_STYLE_URL = "";
 window.config_API_GATEWAY_URI = "";
 window.config_DESKTOP_BRIDGE_URI = "";
+window.config_KEYCLOAK_URI = "";

--- a/scripts/set-env-file-minikube.sh
+++ b/scripts/set-env-file-minikube.sh
@@ -6,7 +6,9 @@ DESKTOP_BRIDGE_PORT=$(kubectl describe service openftth-desktop-bridge -n openft
 API_GATEWAY_HOST=$(minikube ip)
 API_GATEWAY_PORT=$(kubectl describe service openftth-api-gateway -n openftth | grep NodePort -m 1 | grep -o '[0-9]\+')
 
+KEYCLOAK_HOST=$(minikube ip)
+KEYCLOAK_PORT=$(kubectl describe service keycloak -n openftth | grep NodePort -m 1 | grep -o '[0-9]\+')
 
 sed -i "s/window.config_API_GATEWAY_URI.*/window.config_API_GATEWAY_URI = \"$API_GATEWAY_HOST:$API_GATEWAY_PORT\";/" public/config-env.js
-
 sed -i "s/window.config_DESKTOP_BRIDGE_URI.*/window.config_DESKTOP_BRIDGE_URI = \"$DESKTOP_BRIDGE_HOST:$DESKTOP_BRIDGE_PORT\";/" public/config-env.js
+sed -i "s/window.config_KEYCLOAK_URI.*/window.config_KEYCLOAK_URI = \"http\:\/\/$KEYCLOAK_HOST:$KEYCLOAK_PORT\/auth\";/" public/config-env.js

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ declare global {
     config_MAPBOX_STYLE_URL: string;
     config_API_GATEWAY_URI: string;
     config_DESKTOP_BRIDGE_URI: string;
+    config_KEYCLOAK_URI: string;
   }
 }
 
@@ -12,6 +13,7 @@ const settings = {
   MAPBOX_STYLE_URI: window.config_MAPBOX_STYLE_URL,
   API_GATEWAY_URI: window.config_API_GATEWAY_URI,
   DESKTOP_BRIDGE_URI: window.config_DESKTOP_BRIDGE_URI,
+  KEYCLOAK_URI: window.config_KEYCLOAK_URI,
 };
 
 export default settings;

--- a/src/keycloak.ts
+++ b/src/keycloak.ts
@@ -1,9 +1,10 @@
 import Keycloak from "keycloak-js";
+import Config from "./config";
 
 // Setup Keycloak instance as needed
 // Pass initialization options as required or leave blank to load from 'keycloak.json'
 const keycloak = Keycloak({
-  url: "http://10.105.173.49/auth",
+  url: Config.KEYCLOAK_URI,
   realm: "openftth",
   clientId: "openftth-frontend",
 });


### PR DESCRIPTION
Instead of a hardcoded host for keycloak it is now moved into the default config file.