### PR TITLE
adds setup_remote_docker to fix permission issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ jobs:
   build-docker-image:
     executor: docker-publisher
     steps:
+     - setup_remote_docker:
+         version: 19.03.13
      - checkout
      - setup_remote_docker
      - run:
@@ -33,6 +35,8 @@ jobs:
   docker-publish-image:
     executor: docker-publisher
     steps:
+     - setup_remote_docker:
+         version: 19.03.13
      - attach_workspace:
          at: /tmp/workspace
      - setup_remote_docker


### PR DESCRIPTION
The issue is described in this post with the suggested fix.  https://support.circleci.com/hc/en-us/articles/360050934711