### PR TITLE
now uses chart version instead of image tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
              CHART_VERSION="$(./scripts/increment-chart-number.sh "$(grep -w '^version:' ./openftth/Chart.yaml)" bug)"
              sed -i "/^version:.*/c\version: $CHART_VERSION" ./openftth/Chart.yaml
              git add .
-             git commit -m "upgrades $IMAGE_NAME to version $IMAGE_TAG"
+             git commit -m "upgrades $IMAGE_NAME to version $CHART_VERSION"
              git push
 workflows:
   build-test-upload_image:


### PR DESCRIPTION
Fixes a bug where the version is not written to the chart on commit.