### PR TITLE
splits api-gateway into ws and http

### DIFF
--- a/public/config-env_copy.js
+++ b/public/config-env_copy.js
@@ -1,5 +1,6 @@
 window.config_MAPBOX_API_KEY = "";
 window.config_MAPBOX_STYLE_URL = "";
-window.config_API_GATEWAY_URI = "";
+window.config_API_GATEWAY_HTTP_URI = "";
+window.config_API_GATEWAY_WS_URI = "";
 window.config_DESKTOP_BRIDGE_URI = "";
 window.config_KEYCLOAK_URI = "";

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,8 @@ declare global {
   interface Window {
     config_MAPBOX_API_KEY: string;
     config_MAPBOX_STYLE_URL: string;
-    config_API_GATEWAY_URI: string;
+    config_API_GATEWAY_HTTP_URI: string;
+    config_API_GATEWAY_WS_URI: string;
     config_DESKTOP_BRIDGE_URI: string;
     config_KEYCLOAK_URI: string;
   }
@@ -11,7 +12,8 @@ declare global {
 const settings = {
   MAPBOX_API_KEY: window.config_MAPBOX_API_KEY,
   MAPBOX_STYLE_URI: window.config_MAPBOX_STYLE_URL,
-  API_GATEWAY_URI: window.config_API_GATEWAY_URI,
+  API_GATEWAY_HTTP_URI: window.config_API_GATEWAY_HTTP_URI,
+  API_GATEWAY_WS_URI: window.config_API_GATEWAY_WS_URI,
   DESKTOP_BRIDGE_URI: window.config_DESKTOP_BRIDGE_URI,
   KEYCLOAK_URI: window.config_KEYCLOAK_URI,
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,12 +11,14 @@ import "./global-styles/reset.scss";
 import "./global-styles/index.scss";
 
 const subscriptionClient = new SubscriptionClient(
-  `ws://${Config.API_GATEWAY_URI}/graphql`, {
-  reconnect: true
-});
+  `${Config.API_GATEWAY_WS_URI}/graphql`,
+  {
+    reconnect: true,
+  }
+);
 
 const client = new Client({
-  url: `http://${Config.API_GATEWAY_URI}/graphql`,
+  url: `${Config.API_GATEWAY_HTTP_URI}/graphql`,
   exchanges: [
     ...defaultExchanges,
     subscriptionExchange({
@@ -35,5 +37,5 @@ ReactDOM.render(
       </Provider>
     </ReactKeycloakProvider>
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById("root")
 );


### PR DESCRIPTION
Splits the websocket and http endpoints for the api-gateway into two seperate settings. The reason is to make it easier to config for http(s) and ws(s).