### PR TITLE
removes protocol from bridge ws endpoint

### DIFF
--- a/src/bridge/BridgeConnector.tsx
+++ b/src/bridge/BridgeConnector.tsx
@@ -11,7 +11,7 @@ function send(eventMsg: any) {
 
 function BridgeConnector() {
   useEffect(() => {
-    client = new w3cwebsocket(`ws://${Config.DESKTOP_BRIDGE_URI}`);
+    client = new w3cwebsocket(Config.DESKTOP_BRIDGE_URI);
 
     client.onmessage = (message: any) => {
       const event = JSON.parse(message.data);


### PR DESCRIPTION
Removes the ws protocol specified in the bridge-endpoint to enable the use of wss and ws when appropriate.