### PR TITLE
removes async since it causes re-renders

### DIFF
--- a/src/pages/IdentifyFeaturePage/IdentifyFeaturePage.tsx
+++ b/src/pages/IdentifyFeaturePage/IdentifyFeaturePage.tsx
@@ -474,7 +474,7 @@ function IdentifyFeaturePage() {
       <SchematicDiagram
         diagramObjects={diagramObjects}
         envelope={envelope}
-        onSelectFeature={async (x) => await onSelectedFeature(x)}
+        onSelectFeature={onSelectedFeature}
         editMode={editMode}
       />
     </div>


### PR DESCRIPTION
Issues since #95, to fix the issue we removes `async` since it causes re-renders and is not needed.