### PR TITLE
Switch from mapbox-gl to maplibre-gl

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  babel: {
-    loaderOptions: {},
-  },
-};

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,7 +1,5 @@
 module.exports = {
   babel: {
-    loaderOptions: {
-      ignore: ["./node_modules/mapbox-gl/dist/mapbox-gl.js"],
-    },
+    loaderOptions: {},
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
-        "@craco/craco": "^6.1.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.32",
         "@fortawesome/free-solid-svg-icons": "^5.15.1",
         "@fortawesome/react-fontawesome": "^0.1.13",
@@ -38,7 +37,7 @@
       },
       "devDependencies": {
         "@types/jest": "^26.0.20",
-        "@types/mapbox-gl": "^2.1.0",
+        "@types/mapbox-gl": "^1.3.0",
         "@types/node": "^12.19.15",
         "@types/pubsub-js": "^1.8.2",
         "@types/react": "^16.14.2",
@@ -1223,40 +1222,6 @@
       },
       "engines": {
         "node": ">=0.1.95"
-      }
-    },
-    "node_modules/@craco/craco": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-6.1.1.tgz",
-      "integrity": "sha512-4irfOM8RgYNhFJzAXyIuM8CZLju2Jh9GdOem8uqM2/cI2xPulQSxZKU/9q3uiSbFUJfQLi3pomVKii6KzWLu3Q==",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "webpack-merge": "^4.2.2"
-      },
-      "bin": {
-        "craco": "bin/craco.js"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "react-scripts": "^4.0.0"
-      }
-    },
-    "node_modules/@craco/craco/node_modules/semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@csstools/convert-colors": {
@@ -2984,9 +2949,9 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "node_modules/@types/mapbox-gl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.1.0.tgz",
-      "integrity": "sha512-OaLf0MQud7TyEgRYd/JB+ovJjMXJSgeOTFUJspMeJVI/SBEI/2khH7IBM66RiV5x9tpzAnAy68/CkRBLa2NZlw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-1.13.0.tgz",
+      "integrity": "sha512-z5YxncrARfKaJXzkhy4qS0cOldMfGIXq5yOPQcU9S12/xjAe3m66scftYlV1E10Em5QGdW2xahBb3CPk/dDcqA==",
       "dev": true,
       "dependencies": {
         "@types/geojson": "*"
@@ -4803,6 +4768,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
       "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }
@@ -6669,17 +6635,17 @@
       "integrity": "sha512-cev+jOrz/Zm1i+Yh334Hed6lQVOkkemk2wRozfMF4MtTR7pxf3r3L5Rbd7uX1zMcEqVJ7alJBnJL7+JffkC6FQ=="
     },
     "node_modules/elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dependencies": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
@@ -19231,6 +19197,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
       "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }
@@ -20202,14 +20169,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/webpack-merge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
-      "dependencies": {
-        "lodash": "^4.17.15"
       }
     },
     "node_modules/webpack-sources": {
@@ -22201,27 +22160,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@craco/craco": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-6.1.1.tgz",
-      "integrity": "sha512-4irfOM8RgYNhFJzAXyIuM8CZLju2Jh9GdOem8uqM2/cI2xPulQSxZKU/9q3uiSbFUJfQLi3pomVKii6KzWLu3Q==",
-      "requires": {
-        "cross-spawn": "^7.0.0",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "webpack-merge": "^4.2.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
     "@csstools/convert-colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
@@ -23612,9 +23550,9 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/mapbox-gl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.1.0.tgz",
-      "integrity": "sha512-OaLf0MQud7TyEgRYd/JB+ovJjMXJSgeOTFUJspMeJVI/SBEI/2khH7IBM66RiV5x9tpzAnAy68/CkRBLa2NZlw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-1.13.0.tgz",
+      "integrity": "sha512-z5YxncrARfKaJXzkhy4qS0cOldMfGIXq5yOPQcU9S12/xjAe3m66scftYlV1E10Em5QGdW2xahBb3CPk/dDcqA==",
       "dev": true,
       "requires": {
         "@types/geojson": "*"
@@ -26756,17 +26694,17 @@
       "integrity": "sha512-cev+jOrz/Zm1i+Yh334Hed6lQVOkkemk2wRozfMF4MtTR7pxf3r3L5Rbd7uX1zMcEqVJ7alJBnJL7+JffkC6FQ=="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
@@ -38051,14 +37989,6 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
-      }
-    },
-    "webpack-merge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
-      "requires": {
-        "lodash": "^4.17.15"
       }
     },
     "webpack-sources": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "graphql": "^15.4.0",
         "i18next": "^19.8.4",
         "keycloak-js": "^12.0.2",
-        "mapbox-gl": "^2.0.1",
+        "maplibre-gl": "^1.14.0",
         "prop-types": "^15.7.2",
         "pubsub-js": "^1.9.2",
         "react": "^17.0.1",
@@ -2254,9 +2254,12 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-supported": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.0.tgz",
-      "integrity": "sha512-zu4udqYiBrKMQKwpKJ4hhPON7tz0QR/JZ3iGpHnNWFmH3Sv/ysxlICATUtGCFpsyJf2v1WpFhlzaZ3GhhKmPMA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "peerDependencies": {
+        "mapbox-gl": ">=0.32.1 <2.0.0"
+      }
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
@@ -12946,14 +12949,48 @@
       }
     },
     "node_modules/mapbox-gl": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.0.1.tgz",
-      "integrity": "sha512-4sWRh4FztQakCPO/WN2JsMSDOVLKXPSQvHjJgXwIEQtnrxjyFB7Et0VX+h9rDxOA4EB6BRCG8mNgw648/dXNTg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.1.tgz",
+      "integrity": "sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==",
+      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^2.0.0",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
+    "node_modules/maplibre-gl": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-1.14.0.tgz",
+      "integrity": "sha512-pqr/nsoZHx1rUY2Bpp0EFVcFVgrVOLkDDh2DhZcLVZVHYXdFOH/LyKUoLZda/3/CDTmlZy9ldJeZN8O0g1Ocpg==",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
         "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/tiny-sdf": "^1.1.1",
         "@mapbox/unitbezier": "^0.0.0",
@@ -22973,9 +23010,10 @@
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-supported": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.0.tgz",
-      "integrity": "sha512-zu4udqYiBrKMQKwpKJ4hhPON7tz0QR/JZ3iGpHnNWFmH3Sv/ysxlICATUtGCFpsyJf2v1WpFhlzaZ3GhhKmPMA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "requires": {}
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0",
@@ -31743,14 +31781,45 @@
       }
     },
     "mapbox-gl": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.0.1.tgz",
-      "integrity": "sha512-4sWRh4FztQakCPO/WN2JsMSDOVLKXPSQvHjJgXwIEQtnrxjyFB7Et0VX+h9rDxOA4EB6BRCG8mNgw648/dXNTg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.1.tgz",
+      "integrity": "sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==",
+      "peer": true,
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^2.0.0",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      }
+    },
+    "maplibre-gl": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-1.14.0.tgz",
+      "integrity": "sha512-pqr/nsoZHx1rUY2Bpp0EFVcFVgrVOLkDDh2DhZcLVZVHYXdFOH/LyKUoLZda/3/CDTmlZy9ldJeZN8O0g1Ocpg==",
+      "requires": {
+        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
         "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/tiny-sdf": "^1.1.1",
         "@mapbox/unitbezier": "^0.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@craco/craco": "^6.1.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.13",
@@ -32,9 +31,9 @@
     "websocket": "^1.0.33"
   },
   "scripts": {
-    "start": "craco start",
-    "build": "craco build",
-    "test": "craco test",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -57,7 +56,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "@types/mapbox-gl": "^2.1.0",
+    "@types/mapbox-gl": "^1.3.0",
     "@types/node": "^12.19.15",
     "@types/pubsub-js": "^1.8.2",
     "@types/react": "^16.14.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "graphql": "^15.4.0",
     "i18next": "^19.8.4",
     "keycloak-js": "^12.0.2",
-    "mapbox-gl": "^2.0.1",
+    "maplibre-gl": "^1.14.0",
     "prop-types": "^15.7.2",
     "pubsub-js": "^1.9.2",
     "react": "^17.0.1",

--- a/public/config-env_copy.js
+++ b/public/config-env_copy.js
@@ -1,5 +1,3 @@
-window.config_MAPBOX_API_KEY = "";
-window.config_MAPBOX_STYLE_URL = "";
 window.config_API_GATEWAY_HTTP_URI = "";
 window.config_API_GATEWAY_WS_URI = "";
 window.config_DESKTOP_BRIDGE_URI = "";

--- a/src/components/SchematicDiagram/SchematicDiagram.tsx
+++ b/src/components/SchematicDiagram/SchematicDiagram.tsx
@@ -1,7 +1,6 @@
 import { useRef, useEffect } from "react";
 import mapboxgl, { Map, MapboxGeoJSONFeature, PointLike } from "mapbox-gl";
 import { Feature } from "geojson";
-import Config from "../../config";
 import {
   getLayer,
   createFeature,
@@ -180,8 +179,12 @@ function SchematicDiagram({
 
     const newMap = new Map({
       container: mapContainer.current ?? "",
-      style: Config.MAPBOX_STYLE_URI,
-      accessToken: Config.MAPBOX_API_KEY,
+      style: {
+        version: 8,
+        sources: {},
+        layers: [],
+        glyphs: "http://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
+      },
       minZoom: 8,
       center: [0.014, 0.014],
     });

--- a/src/components/SchematicDiagram/diagramLayer.ts
+++ b/src/components/SchematicDiagram/diagramLayer.ts
@@ -158,7 +158,7 @@ export function getLayer(name: string): AnyLayer {
         layout: {
           "text-allow-overlap": true,
           "text-size": 14,
-          "text-font": ["PT Sans Narrow Bold", "Arial Unicode MS Regular"],
+          "text-font": ["Open Sans Bold"],
           "text-field": ["get", "label"],
           "text-anchor": "right",
           "text-justify": "right",
@@ -177,7 +177,7 @@ export function getLayer(name: string): AnyLayer {
         layout: {
           "text-allow-overlap": true,
           "text-size": 14,
-          "text-font": ["PT Sans Narrow Bold", "Arial Unicode MS Regular"],
+          "text-font": ["Open Sans Bold"],
           "text-field": ["get", "label"],
           "text-anchor": "left",
           "text-justify": "left",
@@ -196,7 +196,7 @@ export function getLayer(name: string): AnyLayer {
         layout: {
           "text-allow-overlap": true,
           "text-size": 14,
-          "text-font": ["PT Sans Narrow Bold", "Arial Unicode MS Regular"],
+          "text-font": ["Open Sans Bold"],
           "text-field": ["get", "label"],
           "text-anchor": "right",
           "text-justify": "right",
@@ -216,7 +216,7 @@ export function getLayer(name: string): AnyLayer {
         layout: {
           "text-allow-overlap": true,
           "text-size": 14,
-          "text-font": ["PT Sans Narrow Bold", "Arial Unicode MS Regular"],
+          "text-font": ["Open Sans Bold"],
           "text-field": ["get", "label"],
           "text-anchor": "left",
           "text-justify": "left",
@@ -236,7 +236,7 @@ export function getLayer(name: string): AnyLayer {
         layout: {
           "text-allow-overlap": true,
           "text-size": 14,
-          "text-font": ["PT Sans Narrow Bold", "Arial Unicode MS Regular"],
+          "text-font": ["Open Sans Bold"],
           "text-field": ["get", "label"],
           "text-anchor": "left",
           "text-justify": "left",
@@ -256,7 +256,7 @@ export function getLayer(name: string): AnyLayer {
         layout: {
           "text-allow-overlap": true,
           "text-size": 14,
-          "text-font": ["PT Sans Narrow Bold", "Arial Unicode MS Regular"],
+          "text-font": ["Open Sans Bold"],
           "text-field": ["get", "label"],
           "text-anchor": "left",
           "text-justify": "left",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,5 @@
 declare global {
   interface Window {
-    config_MAPBOX_API_KEY: string;
-    config_MAPBOX_STYLE_URL: string;
     config_API_GATEWAY_HTTP_URI: string;
     config_API_GATEWAY_WS_URI: string;
     config_DESKTOP_BRIDGE_URI: string;
@@ -10,8 +8,6 @@ declare global {
 }
 
 const settings = {
-  MAPBOX_API_KEY: window.config_MAPBOX_API_KEY,
-  MAPBOX_STYLE_URI: window.config_MAPBOX_STYLE_URL,
   API_GATEWAY_HTTP_URI: window.config_API_GATEWAY_HTTP_URI,
   API_GATEWAY_WS_URI: window.config_API_GATEWAY_WS_URI,
   DESKTOP_BRIDGE_URI: window.config_DESKTOP_BRIDGE_URI,


### PR DESCRIPTION
Now that mapbox has changed from an OSS license to a proprietary license we have decided to switch to maplibre-gl.