### PR TITLE
now remove duplicate features

### DIFF
--- a/src/groups/RouteNetworkMap/MapControls/InformationControl.ts
+++ b/src/groups/RouteNetworkMap/MapControls/InformationControl.ts
@@ -129,9 +129,10 @@ function queryFeatures(
     feature: MapboxGeoJSONFeature
   ) => boolean
 ) {
-  return map.queryRenderedFeatures(bbox, {}).filter((x) => {
-    return filter(config, x);
-  });
+  return map
+    .queryRenderedFeatures(bbox, {})
+    .filter((x) => filter(config, x))
+    .filter((v, i, a) => a.findIndex((t) => t.id === v.id) === i);
 }
 
 function createOnClickFunc(


### PR DESCRIPTION
We have experienced issues where mapbox query rendered features returns duplicate features, we now remove all duplicates on mapbox object id.