### PR TITLE
fixes the issue where a bridge disconnect getting state

### DIFF
--- a/src/bridge/BridgeConnector.tsx
+++ b/src/bridge/BridgeConnector.tsx
@@ -161,9 +161,17 @@ function BridgeConnector() {
     // hade been made. The reason for this is that in case the socket is disconnected
     // on the client, we don't want to disturp their workflow by getting the selected
     // feature from the external source, in case they're doing something else.
-    if (!firstTimeIdentifiedFeatureConnection) return;
+    if (
+      !firstTimeIdentifiedFeatureConnection ||
+      !connected ||
+      !websocketClient ||
+      websocketClient.readyState !== 1
+    )
+      return;
+
     retrieveIdentifiedNetworkElement();
   }, [
+    connected,
     firstTimeIdentifiedFeatureConnection,
     retrieveIdentifiedNetworkElement,
     setFirstTimeIdentifiedFeatureConnection,

--- a/src/bridge/BridgeConnector.tsx
+++ b/src/bridge/BridgeConnector.tsx
@@ -28,6 +28,10 @@ function BridgeConnector() {
   const { setSelectedSegmentIds, setIdentifiedFeature, trace, searchResult } =
     useContext(MapContext);
   const [connected, setConnected] = useState(false);
+  const [
+    firstTimeIdentifiedFeatureConnection,
+    setFirstTimeIdentifiedFeatureConnection,
+  ] = useState(false);
   const {
     retrieveSelectedEquipments,
     retrieveIdentifiedNetworkElement,
@@ -139,17 +143,30 @@ function BridgeConnector() {
       }
     );
 
-    retrieveIdentifiedNetworkElement();
+    setFirstTimeIdentifiedFeatureConnection(true);
 
     return () => {
       PubSub.unsubscribe(token);
     };
   }, [
+    setFirstTimeIdentifiedFeatureConnection,
     connected,
-    retrieveIdentifiedNetworkElement,
     setIdentifiedFeature,
     keycloak.profile?.username,
     t,
+  ]);
+
+  useEffect(() => {
+    // We only want to retrieve the identified feature once after the connection
+    // hade been made. The reason for this is that in case the socket is disconnected
+    // on the client, we don't want to disturp their workflow by getting the selected
+    // feature from the external source, in case they're doing something else.
+    if (!firstTimeIdentifiedFeatureConnection) return;
+    retrieveIdentifiedNetworkElement();
+  }, [
+    firstTimeIdentifiedFeatureConnection,
+    retrieveIdentifiedNetworkElement,
+    setFirstTimeIdentifiedFeatureConnection,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
We only want to retrieve the identified feature once after the connection has been made. The reason for this is that in case the socket is disconnected on the client, we don't want to disturb their workflow by getting the selected feature from the external source, in case they're doing something else.       