### PR TITLE
use auth exchange instead of automatic keycloak refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@fortawesome/react-fontawesome": "^0.1.14",
         "@react-keycloak/web": "^3.4.0",
         "@turf/turf": "^6.4.0",
+        "@urql/core": "^3.1.1",
+        "@urql/exchange-auth": "^1.0.0",
         "graphql": "^15.5.1",
         "i18next": "^20.3.2",
         "keycloak-js": "^14.0.0",
@@ -27,7 +29,7 @@
         "sass": "^1.35.1",
         "subscriptions-transport-ws": "^0.9.19",
         "typescript": "^4.3.4",
-        "urql": "^2.0.3",
+        "urql": "^3.0.3",
         "uuid": "^8.3.2",
         "websocket": "^1.0.34"
       },
@@ -2000,14 +2002,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
       "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw=="
-    },
-    "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
     },
     "node_modules/@hapi/address": {
       "version": "2.1.4",
@@ -4998,15 +4992,26 @@
       }
     },
     "node_modules/@urql/core": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-2.3.5.tgz",
-      "integrity": "sha512-kM/um4OjXmuN6NUS/FSm7dESEKWT7By1kCRCmjvU4+4uEoF1cd4TzIhQ7J1I3zbDAFhZzmThq9X0AHpbHAn3bA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
       "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.0",
-        "wonka": "^4.0.14"
+        "wonka": "^6.1.2"
       },
       "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@urql/exchange-auth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-auth/-/exchange-auth-1.0.0.tgz",
+      "integrity": "sha512-79hqPQab+ifeINOxvQykvqub4ixWHBEIagN4U67ijcHGMfp3c4yEWRk4IJMPwF+OMT7LrRFuv+jRIZTQn/9VwQ==",
+      "dependencies": {
+        "@urql/core": ">=3.0.0",
+        "wonka": "^6.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -20169,15 +20174,15 @@
       }
     },
     "node_modules/urql": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/urql/-/urql-2.0.5.tgz",
-      "integrity": "sha512-UOl37CkNO1sfhw8jPihq+9NKUpTLnsRjpK7vmOVqPceqSO0rYXHOAEJp2TWDhyLjn2lYDlDlAfDaxNyK5m1FOA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/urql/-/urql-3.0.3.tgz",
+      "integrity": "sha512-aVUAMRLdc5AOk239DxgXt6ZxTl/fEmjr7oyU5OGo8uvpqu42FkeJErzd2qBzhAQ3DyusoZIbqbBLPlnKo/yy2A==",
       "dependencies": {
-        "@urql/core": "^2.3.2",
-        "wonka": "^4.0.14"
+        "@urql/core": "^3.0.3",
+        "wonka": "^6.0.0"
       },
       "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0",
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
         "react": ">= 16.8.0"
       }
     },
@@ -21836,9 +21841,9 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "node_modules/wonka": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-4.0.15.tgz",
-      "integrity": "sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.2.tgz",
+      "integrity": "sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -23551,12 +23556,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
       "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw=="
-    },
-    "@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
-      "requires": {}
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -25874,12 +25873,20 @@
       }
     },
     "@urql/core": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-2.3.5.tgz",
-      "integrity": "sha512-kM/um4OjXmuN6NUS/FSm7dESEKWT7By1kCRCmjvU4+4uEoF1cd4TzIhQ7J1I3zbDAFhZzmThq9X0AHpbHAn3bA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
       "requires": {
-        "@graphql-typed-document-node/core": "^3.1.0",
-        "wonka": "^4.0.14"
+        "wonka": "^6.1.2"
+      }
+    },
+    "@urql/exchange-auth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-auth/-/exchange-auth-1.0.0.tgz",
+      "integrity": "sha512-79hqPQab+ifeINOxvQykvqub4ixWHBEIagN4U67ijcHGMfp3c4yEWRk4IJMPwF+OMT7LrRFuv+jRIZTQn/9VwQ==",
+      "requires": {
+        "@urql/core": ">=3.0.0",
+        "wonka": "^6.0.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -37842,12 +37849,12 @@
       }
     },
     "urql": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/urql/-/urql-2.0.5.tgz",
-      "integrity": "sha512-UOl37CkNO1sfhw8jPihq+9NKUpTLnsRjpK7vmOVqPceqSO0rYXHOAEJp2TWDhyLjn2lYDlDlAfDaxNyK5m1FOA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/urql/-/urql-3.0.3.tgz",
+      "integrity": "sha512-aVUAMRLdc5AOk239DxgXt6ZxTl/fEmjr7oyU5OGo8uvpqu42FkeJErzd2qBzhAQ3DyusoZIbqbBLPlnKo/yy2A==",
       "requires": {
-        "@urql/core": "^2.3.2",
-        "wonka": "^4.0.14"
+        "@urql/core": "^3.0.3",
+        "wonka": "^6.0.0"
       }
     },
     "use": {
@@ -39180,9 +39187,9 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wonka": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-4.0.15.tgz",
-      "integrity": "sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.2.tgz",
+      "integrity": "sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@react-keycloak/web": "^3.4.0",
     "@turf/turf": "^6.4.0",
+    "@urql/exchange-auth": "^1.0.0",
     "graphql": "^15.5.1",
     "i18next": "^20.3.2",
     "keycloak-js": "^14.0.0",
@@ -22,7 +23,7 @@
     "sass": "^1.35.1",
     "subscriptions-transport-ws": "^0.9.19",
     "typescript": "^4.3.4",
-    "urql": "^2.0.3",
+    "urql": "^3.0.3",
     "uuid": "^8.3.2",
     "websocket": "^1.0.34"
   },

--- a/src/groups/RouteNetworkDiagram/OutageView/OutageViewGql.ts
+++ b/src/groups/RouteNetworkDiagram/OutageView/OutageViewGql.ts
@@ -10,7 +10,7 @@ export function getInformation(client: Client, routeNetworkElementId: string) {
 
 export function getWorkTasks(client: Client) {
   return client
-    .query<LatestTenTroubleTicketsResponse>(LATEST_TEN_TROUBLE_TICKETS_ORDERED_BY_DATE_QUERY)
+    .query<LatestTenTroubleTicketsResponse>(LATEST_TEN_TROUBLE_TICKETS_ORDERED_BY_DATE_QUERY, {})
     .toPromise();
 }
 

--- a/src/groups/TerminalEquipment/AddAdditionalStructures/AddAdditionalStructuresGql.ts
+++ b/src/groups/TerminalEquipment/AddAdditionalStructures/AddAdditionalStructuresGql.ts
@@ -3,7 +3,7 @@ import { Client } from "urql";
 export function getTerminalStructureSpecifications(client: Client) {
   return client
     .query<TerminalStructureSpecificationResponse>(
-      TERMINAL_STRUCTURE_SPECIFICATION_QUERY
+      TERMINAL_STRUCTURE_SPECIFICATION_QUERY, {}
     )
     .toPromise();
 }

--- a/src/groups/TerminalEquipment/EditRack/EditRackGql.ts
+++ b/src/groups/TerminalEquipment/EditRack/EditRackGql.ts
@@ -2,7 +2,7 @@ import { Client } from "urql";
 
 export function queryRackSpecifications(client: Client) {
   return client
-    .query<RackSpecificationsResponse>(QUERY_RACK_SPECIFICATIONS)
+    .query<RackSpecificationsResponse>(QUERY_RACK_SPECIFICATIONS, {})
     .toPromise();
 }
 

--- a/src/groups/TerminalEquipment/EditTerminalEquipment/EditTerminalEquipmentGql.ts
+++ b/src/groups/TerminalEquipment/EditTerminalEquipment/EditTerminalEquipmentGql.ts
@@ -21,7 +21,7 @@ export function queryTerminalEquipmentDetails(
 export function queryTerminalEquipmentSpecifications(client: Client) {
   return client
     .query<SpanEquipmentSpecificationsResponse>(
-      QUERY_TERMINAL_EQUIPMENT_SPECIFICATIONS
+      QUERY_TERMINAL_EQUIPMENT_SPECIFICATIONS, {}
     )
     .toPromise();
 }

--- a/src/groups/WorkTasks/WorkTasksGql.ts
+++ b/src/groups/WorkTasks/WorkTasksGql.ts
@@ -1,7 +1,7 @@
 import { Client } from "urql";
 
 export function getWorksTasks(client: Client) {
-  return client.query<WorkTasksResponse>(QUERY_WORK_TASKS).toPromise();
+  return client.query<WorkTasksResponse>(QUERY_WORK_TASKS, {}).toPromise();
 }
 
 export function setCurrentWorkTaskToUser(


### PR DESCRIPTION
We have had issues with automatic JWT refresh did not always work. We have now switched to using `authExchange` from urql with our own implementation of token refreshing.