### PR TITLE
unit address required on terminal equipment, access address selected

### DIFF
--- a/src/translation/translation.json
+++ b/src/translation/translation.json
@@ -265,7 +265,8 @@
       "VIOLET": "Violet",
       "TURQUOISE": "Turquoise",
       "MESSAGE_HAS_BEEN_SENT": "Message has been sent",
-      "COULD_NOT_FIND_LOCATION": "Could not find the location"
+      "COULD_NOT_FIND_LOCATION": "Could not find the location",
+      "UNIT_ADDRESS_REQUIRED": "Unit address is required."
     }
   },
   "dk": {
@@ -534,7 +535,8 @@
       "VIOLET": "Violet",
       "TURQUOISE": "Turkis",
       "MESSAGE_HAS_BEEN_SENT": "Beskeden er sendt",
-      "COULD_NOT_FIND_LOCATION": "Kunne ikke finde lokationen"
+      "COULD_NOT_FIND_LOCATION": "Kunne ikke finde lokationen",
+      "UNIT_ADDRESS_REQUIRED": "Enhedsadresse er påkrævet."
     }
   }
 }


### PR DESCRIPTION
Now only shows unit address if there is one to select. It will automatically select the unit address if there is only a single one available. When access address is selected and multiple options are available, it will be required by the user to select a unit address.