### PR TITLE
now sets max-height for toggle list

### DIFF
--- a/src/groups/RouteNetworkMap/MapControls/ToggleLayerButton.scss
+++ b/src/groups/RouteNetworkMap/MapControls/ToggleLayerButton.scss
@@ -25,6 +25,8 @@
   top: 0px;
   box-shadow: 0 0 0 2px rgb(0 0 0 / 10%);
   visibility: hidden;
+  max-height: 350px;
+  overflow-y: auto;
 
   &.toggle-list--visible {
     visibility: visible;


### PR DESCRIPTION
Fixes issue where the toggle list cannot be seen if it is very large on smaller devices.