### PR TITLE
decrease max-height of menu option to avoid overflow

### DIFF
--- a/src/components/SelectMenu/SelectMenu.scss
+++ b/src/components/SelectMenu/SelectMenu.scss
@@ -68,7 +68,7 @@
   visibility: hidden;
   pointer-events: none;
   z-index: 2;
-  max-height: 200px;
+  max-height: 175px;
   overflow-y: auto;
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;


### PR DESCRIPTION
Issue where the menu option overflows the screen, reducing the size a bit fixes the problem.